### PR TITLE
fix disappearing map when switching locales

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'i18n-js'
 gem 'jquery-rails', '~> 4.0.0.beta2'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
+# Fixes problem with JS stopped working after switching page using turbolins
+gem 'jquery-turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0.beta, < 5.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.1)
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
@@ -181,6 +184,7 @@ DEPENDENCIES
   i18n-js
   jbuilder (~> 2.0)
   jquery-rails (~> 4.0.0.beta2)
+  jquery-turbolinks
   pg
   rails (= 4.2.0.rc2)
   rails-assets-esri-leaflet (= 1.0.0.rc.4)

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -1,4 +1,5 @@
 #= require jquery
+#= require jquery.turbolinks
 #= require jquery_ujs
 #= require turbolinks
 #= require i18n


### PR DESCRIPTION
Some js libraries are not turbolinks ready. As a conclusion after switching  page some elements crash. In our case map disappeared and tooltips stopped to work. It is solved by `jquery-turbolinks` gem.
