### PR TITLE
district on-click centering, zooming and replacing with detailed zoning

### DIFF
--- a/app/assets/javascripts/popup_templates.js.coffee
+++ b/app/assets/javascripts/popup_templates.js.coffee
@@ -8,7 +8,7 @@ class @PopupTemplates
 
   # Popup templates for features; what is displayed depends on the returned WFS server feature data
   # Run as dynamic functions in order to be able to use proper locales
-  @districtPopupTemplate: -> """
+  @districtPopupTemplate = -> """
       <h3>{NAZWA}{NR_PLANU}</h3>#{I18n.t('krakow.mpzp.Status')}: {STATUS}<br>
       #{I18n.t('map.dates')}:<br><small>
         #{I18n.t('krakow.mpzp.DATA_PRZYS')}: {DATA_PRZYS}<br>
@@ -21,7 +21,7 @@ class @PopupTemplates
       <small>#{I18n.t('krakow.mpzp.FID')}: {FID}</small>
     """
 
-  @zonePopupTemplate: -> """
+  @zonePopupTemplate = -> """
     <h3>{OZNACZENIE} ({RODZAJ_OZN})</h3>
     #{I18n.t('map.dates')}:<br><small>
       #{I18n.t('krakow.mpzp.DATA_AKTUA')}: {DATA_AKTUA}<br>

--- a/app/assets/javascripts/zoning_map.js.coffee
+++ b/app/assets/javascripts/zoning_map.js.coffee
@@ -41,22 +41,35 @@ class @ZoningMap
           layer.resetStyle(oldSelectedDistrictId)
         oldSelectedDistrictId = featureId
         layer.setFeatureStyle featureId, ->
-          color: color,
-          weight: 5,
+          color: color
+          weight: 5
           opacity: 1
 
     clickFunc = (e, color, layer) ->
       layer.resetStyle(oldClickedDistrictId)
       oldClickedDistrictId = e.layer.feature.id
       layer.setFeatureStyle e.layer.feature.id, ->
-        color: color,
-        weight: 5,
+        color: color
+        weight: 5
         opacity: 1
+
+    @detailedZoning.on 'load', (e) =>
+      # Switch district countours off when detailed zoning is shown
+      @zoningMap.removeLayer @districtContours
+
+    @districtClickCallback = (e) =>
+      # Zoom to the district
+      district = @districtContours.getFeature e.layer.feature.id
+      @zoningMap.fitBounds district.getBounds()
+      # Query detailed zoning for that district only and show it
+      @detailedZoning.setWhere 'OGLOSZENIE="' + e.layer.feature.properties.OGLOSZENIE + '"'
+      @zoningMap.addLayer @detailedZoning
 
     @districtContours.on 'mouseover', (e) =>
       mouseoverFunc(e, '#60ba39', @districtContours)
     @districtContours.on 'click', (e) =>
       clickFunc(e, '#326E18', @districtContours)
+      @districtClickCallback(e)
 
     @detailedZoning.on 'mouseover', (e) =>
       mouseoverFunc(e, '#dd4439', @detailedZoning)
@@ -64,7 +77,7 @@ class @ZoningMap
       clickFunc(e, '#B5423A', @detailedZoning)
 
     # Binding popup templates to features of both layers, to be shown on feature click
-    PopupTemplates.bindPopup @districtContours, PopupTemplates.districtPopupTemplate()
+#    PopupTemplates.bindPopup @districtContours, PopupTemplates.districtPopupTemplate()
     PopupTemplates.bindPopup @detailedZoning, PopupTemplates.zonePopupTemplate()
 
     # Let's start with district contours


### PR DESCRIPTION
This does not work perfectly yet, but is a good basis for further development. After you click on a district, it should be zoomed in and the layer should be replaced by the detailed zoning layer, for this district only.

For now, use the upper panel zoom icon to go back to the districts layers.

The detailed zoning query is on "OGLOSZENIE" now, perhaps it should be on "NAZWA_MPZP". No other (e.g. number based) relation is present in the data.

Some districts do not have detailed zoning data - it might be the case that the ArcGIS server does not provide anything for plans that are SPORZĄDZANE. In such a case it's quite a trouble for us - it would be very interesting to have these as well... Perhaps some inquiry in the Biuro Planowania Przestrzennego would give us some hint on where to look for that data.
