### PR TITLE
basic comment model and recently_commented discussion scope

### DIFF
--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -5,8 +5,8 @@ class @Discussions
     $('body').on 'show.bs.collapse', '.discussion-body', ->
       discussionId = $(this).attr('data-discussion')
       discussionPath = Routes.discussion_path(
+        discussionId,
         locale: I18n.locale
-        id: discussionId
       )
       $.get discussionPath, (data) =>
         $("[data-discussion=#{discussionId}] .panel-body").html data

--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -24,4 +24,4 @@ class @Discussions
         $('#discussions-tab').html data
 
     $('body').on 'ajax:success', '.delete', (evt, data, status, xhr) ->
-      $(this).parent().parent().parent().fadeOut()
+      $(this).parents('.panel').fadeOut()

--- a/app/assets/stylesheets/discussions.scss
+++ b/app/assets/stylesheets/discussions.scss
@@ -4,11 +4,15 @@
 
 .discussion-list {
 
-  color: black;
+  color: #525252;
 
   .panel-title {
     color: #436E90;
     font-weight: bold;
+  }
+
+  .panel-body {
+    background-color: #FBFBF0;
   }
 
 }

--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -6,7 +6,7 @@
 }
 
 a.logo:hover {
-  color: #525252;
+  color: white;
   text-decoration: none;
 }
 

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -15,6 +15,7 @@ class DiscussionsController < ApplicationController
   end
 
   def show
+    @discussion = Discussion.find params[:id]
   end
 
   def create

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -10,6 +10,7 @@ class DiscussionsController < ApplicationController
     if params[:fid]
       @discussions = Discussion.about_fid params[:fid]
     else
+      @recently_commented = Discussion.recently_commented.all
       render 'recent'
     end
   end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -8,8 +8,9 @@ class DiscussionsController < ApplicationController
 
   def index
     if params[:fid]
-      @discussions = Discussion.about_fid params[:fid]
+      @discussions = Discussion.about params[:fid]
     else
+      @recently_created = Discussion.recently_created
       @recently_commented = Discussion.recently_commented.all
       render 'recent'
     end
@@ -22,7 +23,7 @@ class DiscussionsController < ApplicationController
   def create
     @discussion.save!
 
-    @discussions = Discussion.about_fid params[:discussion][:fid]
+    @discussions = Discussion.about params[:discussion][:fid]
     render partial: 'list', object: @discussions
   end
 

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -1,0 +1,12 @@
+module DiscussionsHelper
+
+  # Show 'time since' in a user friendly way
+  def time_ago(time)
+    if Time.now < time || Time.now - time > 1.day
+      l(time.in_time_zone('CET'), format: :short)
+    else
+      time_ago_in_words(time) + ' ' + t('datetime.ago')
+    end
+  end
+
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -3,7 +3,12 @@ class Ability
 
   def initialize(user)
     if user
-      can [:create, :destroy], Discussion, author_id: user.id
+      can :create, Discussion, author_id: user.id
+
+      can :destroy, Discussion do |discussion|
+        discussion.author_id == user.id &&
+          discussion.comments.by(user) == discussion.comments
+      end
     end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,18 @@
+class Comment < ActiveRecord::Base
+
+  belongs_to :author,
+             class_name: 'User',
+             foreign_key: 'author_id',
+             required: true
+
+  belongs_to :discussion,
+             required: true
+
+  # Thread is our name for a set of comments replying to another comment
+  belongs_to :thread, class_name: 'Comment'
+
+  has_many :replies,
+           class_name: 'Comment',
+           foreign_key: 'thread_id'
+
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,6 +15,8 @@ class Comment < ActiveRecord::Base
            class_name: 'Comment',
            foreign_key: 'thread_id'
 
+  default_scope { order(:created_at) }
+
   scope :by, ->(user) { where(author: user) }
 
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -15,4 +15,6 @@ class Comment < ActiveRecord::Base
            class_name: 'Comment',
            foreign_key: 'thread_id'
 
+  scope :by, ->(user) { where(author: user) }
+
 end

--- a/app/models/concerns/nondeletable.rb
+++ b/app/models/concerns/nondeletable.rb
@@ -14,7 +14,8 @@ module Nondeletable extend ActiveSupport::Concern
 
   def prevent_destroy
     logger.error "PREVENTING DESTROY of #{self.class.name}!!!"
-    errors.add :base, "Entities of #{self.class.name} cannot be destroyed!"
+    errors.add :base,
+      I18n.t('errors.messages.nondeletable', class_name: self.class.name)
     false
   end
 

--- a/app/models/concerns/nondeletable.rb
+++ b/app/models/concerns/nondeletable.rb
@@ -1,0 +1,21 @@
+# Provides a Concern for any Model class entities of which should NEVER be destroyed.
+# In model class use it with
+#   include Nondeletable
+# somewhere inside the model class definition. This guards against "destroy", probably
+# not effective against "delete".
+
+module Nondeletable extend ActiveSupport::Concern
+
+  included do
+    before_destroy :prevent_destroy
+  end
+
+  private
+
+  def prevent_destroy
+    logger.error "PREVENTING DESTROY of #{self.class.name}!!!"
+    errors.add :base, "Entities of #{self.class.name} cannot be destroyed!"
+    false
+  end
+
+end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -13,7 +13,7 @@ class Discussion < ActiveRecord::Base
 
   scope :newest_first, -> { order(created_at: :desc) }
 
-  scope :about_fid, ->(fid) { where(fid: fid).newest_first }
+  scope :about, ->(fid) { where(fid: fid).newest_first }
 
   scope :recently_created, -> { newest_first.limit(5) }
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -4,9 +4,12 @@ class Discussion < ActiveRecord::Base
              foreign_key: 'author_id',
              required: true
 
-  has_many :comments
+  has_many :comments, dependent: :destroy
 
   validates_presence_of :fid
+
+  before_destroy :check_comments, prepend: true
+
 
   scope :newest_first, -> { order(created_at: :desc) }
 
@@ -30,5 +33,19 @@ class Discussion < ActiveRecord::Base
     #    ORDER BY SORT DESC
     #    LIMIT 5')
   }
+
+  # Please note it does NOT include the discussion author unless that user
+  # is also an author of at least a single comment in this discussion
+  def commenters
+    # User.joins(:comments).where(comments: {discussion_id: id}).uniq
+    User.where(id: comments.pluck(:author_id))
+  end
+
+
+  private
+
+  def check_comments
+    commenters.count < 2
+  end
 
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -13,19 +13,20 @@ class Discussion < ActiveRecord::Base
   scope :recently_created, -> { order(created_at: :desc).limit(5) }
 
   scope :recently_commented, -> {
-    # select('discussions.id', 'MAX(comments.created_at)').
-    # joins(:comments).
-    # group('discussions.id').
-    # order('MAX(comments.created_at) DESC').
-    # limit(5)
+    select('discussions.*', 'MAX(comments.created_at)').
+    joins(:comments).
+    group('discussions.id').
+    order('MAX(comments.created_at) DESC').
+    limit(5)
 
-    find_by_sql(
-      'SELECT discussions.*, MAX(comments.created_at) AS sort
-       FROM discussions
-       INNER JOIN comments ON comments.discussion_id = discussions.id
-       GROUP BY discussions.id
-       ORDER BY SORT DESC
-       LIMIT 5')
+    # # The original SQL version
+    # find_by_sql(
+    #   'SELECT discussions.*, MAX(comments.created_at) AS sort
+    #    FROM discussions
+    #    INNER JOIN comments ON comments.discussion_id = discussions.id
+    #    GROUP BY discussions.id
+    #    ORDER BY SORT DESC
+    #    LIMIT 5')
   }
 
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -4,14 +4,28 @@ class Discussion < ActiveRecord::Base
              foreign_key: 'author_id',
              required: true
 
+  has_many :comments
+
   validates_presence_of :fid
 
   scope :about_fid, ->(fid) { where(fid: fid).order(:created_at) }
 
   scope :recently_created, -> { order(created_at: :desc).limit(5) }
 
-  # TODO FIXME add :recently_commented scope to return 5 discussion
-  # with the most recent comments
-  # scope :recently_commented, -> { order(created_at: :desc).limit(5) }
+  scope :recently_commented, -> {
+    # select('discussions.id', 'MAX(comments.created_at)').
+    # joins(:comments).
+    # group('discussions.id').
+    # order('MAX(comments.created_at) DESC').
+    # limit(5)
+
+    find_by_sql(
+      'SELECT discussions.*, MAX(comments.created_at) AS sort
+       FROM discussions
+       INNER JOIN comments ON comments.discussion_id = discussions.id
+       GROUP BY discussions.id
+       ORDER BY SORT DESC
+       LIMIT 5')
+  }
 
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -8,9 +8,11 @@ class Discussion < ActiveRecord::Base
 
   validates_presence_of :fid
 
-  scope :about_fid, ->(fid) { where(fid: fid).order(:created_at) }
+  scope :newest_first, -> { order(created_at: :desc) }
 
-  scope :recently_created, -> { order(created_at: :desc).limit(5) }
+  scope :about_fid, ->(fid) { where(fid: fid).newest_first }
+
+  scope :recently_created, -> { newest_first.limit(5) }
 
   scope :recently_commented, -> {
     select('discussions.*', 'MAX(comments.created_at)').

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,16 @@
 class User < ActiveRecord::Base
+
+  include Nondeletable
+
   devise :rememberable,
          :trackable,
          :omniauthable,
          omniauth_providers: [:facebook, :google_oauth2]
 
   has_many :discussions,
+           foreign_key: 'author_id'
+
+  has_many :comments,
            foreign_key: 'author_id'
 
   def self.from_omniauth(auth)
@@ -15,4 +21,5 @@ class User < ActiveRecord::Base
       user.image = auth.info.image
     end
   end
+
 end

--- a/app/views/discussions/_list.html.haml
+++ b/app/views/discussions/_list.html.haml
@@ -13,7 +13,7 @@
               = discussion.title
           .pull-right
             - if can?(:destroy, discussion)
-              = link_to discussion_path(I18n.locale, discussion),
+              = link_to discussion_path(id: discussion.id),
                         method: :delete, remote: true, class: 'delete',
                         data: { confirm: t('discussions.delete_confirmation') } do
                 = icon('times')

--- a/app/views/discussions/_list.html.haml
+++ b/app/views/discussions/_list.html.haml
@@ -1,11 +1,11 @@
 - if list.present?
 
-  .panel-group#discussion-list{ role: 'tablist' }
+  .panel-group.discussion-list{ role: 'tablist' }
     - list.each do |discussion|
       .panel.panel-default
         .panel-heading{ role: 'tab' }
           %a.collapsed{ href: "[data-discussion=#{discussion.id}]",
-          data: { toggle: 'collapse', parent: '#discussion-list' }}
+          data: { toggle: 'collapse', parent: '.discussion-list' }}
             - if discussion.title.empty?
               = t 'discussions.discussion.title.default',
                   id: discussion.id, fid: discussion.fid

--- a/app/views/discussions/recent.html.haml
+++ b/app/views/discussions/recent.html.haml
@@ -15,12 +15,10 @@
            object: Discussion.recently_created,
            locals: { nothing: t('.no_discussions') }
 
-  - recently_commented = Discussion.recently_commented.all
-
-  - if recently_commented.present?
+  - if @recently_commented.present?
 
     %h4.text-center
       = t '.recently_commented_title'
 
     = render partial: 'list',
-             object: recently_commented
+             object: @recently_commented

--- a/app/views/discussions/recent.html.haml
+++ b/app/views/discussions/recent.html.haml
@@ -15,10 +15,12 @@
            object: Discussion.recently_created,
            locals: { nothing: t('.no_discussions') }
 
-  -# TODO FIXME show 5 discussions with the latest comments in them
-  -#%h4.text-center
-  -#  = t '.recently_commented_title'
-  -#
-  -#= render partial: 'list',
-  -#         object: Discussion.recently_commented,
-  -#         locals: { nothing: t('.no_discussions') }
+  - recently_commented = Discussion.recently_commented.all
+
+  - if recently_commented.present?
+
+    %h4.text-center
+      = t '.recently_commented_title'
+
+    = render partial: 'list',
+             object: recently_commented

--- a/app/views/discussions/recent.html.haml
+++ b/app/views/discussions/recent.html.haml
@@ -12,7 +12,7 @@
     = t '.recently_created_title'
 
   = render partial: 'list',
-           object: Discussion.recently_created,
+           object: @recently_created,
            locals: { nothing: t('.no_discussions') }
 
   - if @recently_commented.present?

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -1,0 +1,10 @@
+- @discussion.comments.each do |comment|
+  .box
+    .avatar
+      %img{ src: comment.author.image }
+    .page-feed-content
+      %small.time
+        = comment.author.name
+        = time_ago_in_words comment.created_at
+      %p
+        = comment.content

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -5,6 +5,6 @@
     .page-feed-content
       %small.time
         = comment.author.name
-        = comment.created_at
+        = time_ago comment.created_at
       %p
         = comment.content

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -5,6 +5,6 @@
     .page-feed-content
       %small.time
         = comment.author.name
-        = time_ago_in_words comment.created_at
+        = comment.created_at
       %p
         = comment.content

--- a/config/locales/basics.en.yml
+++ b/config/locales/basics.en.yml
@@ -131,6 +131,7 @@ en:
         one: is the wrong length (should be 1 character)
         other: is the wrong length (should be %{count} characters)
       other_than: "must be other than %{count}"
+      nondeletable: "Entities of %{class_name} cannot be destroyed!"
     template:
       body: ! 'There were problems with the following fields:'
       header:

--- a/config/locales/basics.en.yml
+++ b/config/locales/basics.en.yml
@@ -1,0 +1,205 @@
+en:
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: ! '%Y-%m-%d'
+      long: ! '%B %d, %Y'
+      short: ! '%b %d'
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_days:
+        one: 1 day
+        other: ! '%{count} days'
+      x_minutes:
+        one: 1 minute
+        other: ! '%{count} minutes'
+      x_months:
+        one: 1 month
+        other: ! '%{count} months'
+      x_seconds:
+        one: 1 second
+        other: ! '%{count} seconds'
+    prompts:
+      day: Day
+      hour: Hour
+      minute: Minute
+      month: Month
+      second: Seconds
+      year: Year
+    ago: ago
+  errors:
+    format: ! '%{attribute} %{message}'
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      present: must be blank
+      confirmation: ! "doesn't match %{attribute}"
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      record_invalid: ! 'Validation failed: %{errors}'
+      restrict_dependent_destroy:
+        one: "Cannot delete record because a dependent %{record} exists"
+        many: "Cannot delete record because dependent %{record} exist"
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+      other_than: "must be other than %{count}"
+    template:
+      body: ! 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: ! '%{count} errors prohibited this %{model} from being saved'
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ! ','
+        format: ! '%u%n'
+        precision: 2
+        separator: .
+        significant: false
+        strip_insignificant_zeros: false
+        unit: $
+    format:
+      delimiter: ! ','
+      precision: 3
+      separator: .
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: ! '%n %u'
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: ! '%n %u'
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ! ', and '
+      two_words_connector: ! ' and '
+      words_connector: ! ', '
+  time:
+    am: am
+    formats:
+      default: ! '%a, %d %b %Y %H:%M:%S %z'
+      long: ! '%B %d, %Y %H:%M'
+      short: ! '%d %b %H:%M'
+    pm: pm

--- a/config/locales/basics.pl.yml
+++ b/config/locales/basics.pl.yml
@@ -159,6 +159,7 @@ pl:
         one: ma nieprawidłową długość (powinna wynosić jeden znak)
         other: ma nieprawidłową długość (powinna wynosić %{count} znaków)
       other_than: 'musi być inna niż %{count}'
+      nondeletable: "Obiektów klasy %{class_name} nie można kasować!"
     template:
       body: ! 'Błędy dotyczą następujących pól:'
       header:

--- a/config/locales/basics.pl.yml
+++ b/config/locales/basics.pl.yml
@@ -1,0 +1,237 @@
+pl:
+  date:
+    abbr_day_names:
+    - nie
+    - pon
+    - wto
+    - śro
+    - czw
+    - pią
+    - sob
+    abbr_month_names:
+    -
+    - sty
+    - lut
+    - mar
+    - kwi
+    - maj
+    - cze
+    - lip
+    - sie
+    - wrz
+    - paź
+    - lis
+    - gru
+    day_names:
+    - niedziela
+    - poniedziałek
+    - wtorek
+    - środa
+    - czwartek
+    - piątek
+    - sobota
+    formats:
+      default: ! '%d-%m-%Y'
+      long: ! '%B %d, %Y'
+      short: ! '%d %b'
+    month_names:
+    -
+    - styczeń
+    - luty
+    - marzec
+    - kwiecień
+    - maj
+    - czerwiec
+    - lipiec
+    - sierpień
+    - wrzesień
+    - październik
+    - listopad
+    - grudzień
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        few: około %{count} godziny
+        many: około %{count} godzin
+        one: około godziny
+        other: około %{count} godzin
+      about_x_months:
+        few: około %{count} miesiące
+        many: około %{count} miesięcy
+        one: około miesiąca
+        other: około %{count} miesięcy
+      about_x_years:
+        few: około %{count} lata
+        many: około %{count} lat
+        one: około rok
+        other: około %{count} lat
+      almost_x_years:
+        few: prawie %{count} lata
+        many: prawie %{count} lat
+        one: prawie rok
+        other: prawie %{count} lat
+      half_a_minute: pół minuty
+      less_than_x_minutes:
+        few: mniej niż %{count} minuty
+        many: mniej niż %{count} minut
+        one: mniej niż minutę
+        other: mniej niż %{count} minut
+      less_than_x_seconds:
+        few: mniej niż %{count} sekundy
+        many: mniej niż %{count} sekund
+        one: mniej niż sekundę
+        other: mniej niż %{count} sekund
+      over_x_years:
+        few: ponad %{count} lata
+        many: ponad %{count} lat
+        one: ponad rok
+        other: ponad %{count} lat
+      x_days:
+        few: ! '%{count} dni'
+        many: ! '%{count} dni'
+        one: 1 dzień
+        other: ! '%{count} dni'
+      x_minutes:
+        few: ! '%{count} minuty'
+        many: ! '%{count} minut'
+        one: 1 minuta
+        other: ! '%{count} minut'
+      x_months:
+        few: ! '%{count} miesiące'
+        many: ! '%{count} miesięcy'
+        one: 1 miesiąc
+        other: ! '%{count} miesięcy'
+      x_seconds:
+        few: ! '%{count} sekundy'
+        many: ! '%{count} sekund'
+        one: 1 sekunda
+        other: ! '%{count} sekund'
+    prompts:
+      day: Dzień
+      hour: Godzina
+      minute: Minuta
+      month: Miesiąc
+      second: Sekundy
+      year: Rok
+    ago: temu
+  errors:
+    format: ! '%{attribute} %{message}'
+    messages:
+      accepted: musi zostać zaakceptowane
+      blank: nie może być puste
+      confirmation: ! 'nie zgadza się z polem %{attribute}'
+      empty: nie może być puste
+      equal_to: musi być równe %{count}
+      even: musi być parzyste
+      exclusion: jest zarezerwowane
+      greater_than: musi być większe od %{count}
+      greater_than_or_equal_to: musi być większe lub równe %{count}
+      inclusion: nie znajduje się na liście dopuszczalnych wartości
+      invalid: jest nieprawidłowe
+      less_than: musi być mniejsze od %{count}
+      less_than_or_equal_to: musi być mniejsze lub równe %{count}
+      not_a_number: nie jest liczbą
+      not_an_integer: musi być liczbą całkowitą
+      odd: musi być nieparzyste
+      present: musi być puste
+      record_invalid: ! 'Negatywne sprawdzenie poprawności: %{errors}'
+      restrict_dependent_destroy:
+        many: 'Nie może zostać usunięte, gdyż istnieją zależne od niego %{record}'
+        one: 'Nie może zostać usunięte, gdyż istnieje zależny od niego %{record}'
+      taken: zostało już zajęte
+      too_long:
+        few: jest za długie (maksymalnie %{count} znaki)
+        many: jest za długie (maksymalnie %{count} znaków)
+        one: jest za długie (maksymalnie jeden znak) 
+        other: jest za długie (maksymalnie %{count} znaków)
+      too_short:
+        few: jest za krótkie (przynajmniej %{count} znaki)
+        many: jest za krótkie (przynajmniej %{count} znaków)
+        one: jest za krótkie (przynajmniej jeden znak)
+        other: jest za krótkie (przynajmniej %{count} znaków)
+      wrong_length:
+        few: ma nieprawidłową długość (powinna wynosić %{count} znaki)
+        many: ma nieprawidłową długość (powinna wynosić %{count} znaków)
+        one: ma nieprawidłową długość (powinna wynosić jeden znak)
+        other: ma nieprawidłową długość (powinna wynosić %{count} znaków)
+      other_than: 'musi być inna niż %{count}'
+    template:
+      body: ! 'Błędy dotyczą następujących pól:'
+      header:
+        few: ! '%{model} nie został zachowany z powodu %{count} błędów'
+        many: ! '%{model} nie został zachowany z powodu %{count} błędów'
+        one: ! '%{model} nie został zachowany z powodu jednego błędu'
+        other: ! '%{model} nie został zachowany z powodu %{count} błędów'
+  helpers:
+    select:
+      prompt: Proszę wybrać
+    submit:
+      create: Utwórz %{model}
+      submit: Zapisz %{model}
+      update: Aktualizuj %{model}
+  number:
+    currency:
+      format:
+        delimiter: ! ' '
+        format: ! '%n %u'
+        precision: 2
+        separator: ! ','
+        significant: false
+        strip_insignificant_zeros: true
+        unit: zł
+    format:
+      delimiter: ! ' '
+      precision: 3
+      separator: ! ','
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: ! '%n %u'
+        units:
+          billion: Miliard
+          million: Milion
+          quadrillion: Biliard
+          thousand: Tysiąc
+          trillion: Bilion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: ! '%n %u'
+        units:
+          byte:
+            few: bajty
+            many: bajtów
+            one: bajt
+            other: bajty
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: '%n%'
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ! ' oraz '
+      two_words_connector: ! ' i '
+      words_connector: ! ', '
+  time:
+    am: przed południem
+    formats:
+      default: ! '%a, %d %b %Y %H:%M:%S %z'
+      long: ! '%B %d, %Y %H:%M'
+      short: ! '%d %b %H:%M'
+    pm: po południu

--- a/config/locales/plurals.rb
+++ b/config/locales/plurals.rb
@@ -1,0 +1,31 @@
+# More rules in this file: https://github.com/svenfuchs/i18n/blob/master/test/test_data/locales/plurals.rb
+I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+{
+  pl: {
+    i18n: {
+      plural: {
+        keys: [:one, :few, :other],
+        rule: lambda { |n|
+          if n == 1
+            :one
+          else
+            if [2, 3, 4].include?(n % 10) && ![12, 13, 14].include?(n % 100)
+              :few
+            else
+              :other
+            end
+          end
+        }
+      }
+    }
+  },
+
+  en: {
+    i18n: {
+      plural: {
+        keys: [:one, :other],
+        rule: lambda { |n| n == 1 ? :one : :other }
+      }
+    }
+  }
+}

--- a/db/migrate/20141229095838_create_discussions.rb
+++ b/db/migrate/20141229095838_create_discussions.rb
@@ -1,10 +1,13 @@
 class CreateDiscussions < ActiveRecord::Migration
   def change
     create_table :discussions do |t|
-      t.integer :fid,     null: false
+      t.integer :fid, null: false
       t.string  :title
+      t.integer :author_id, index: true, null: false
 
       t.timestamps null: false
     end
+
+    add_foreign_key :discussions, :users, column: :author_id
   end
 end

--- a/db/migrate/20141229095838_create_discussions.rb
+++ b/db/migrate/20141229095838_create_discussions.rb
@@ -3,7 +3,7 @@ class CreateDiscussions < ActiveRecord::Migration
     create_table :discussions do |t|
       t.integer :fid, null: false
       t.string  :title
-      t.integer :author_id, index: true, null: false
+      t.belongs_to :author, index: true, null: false
 
       t.timestamps null: false
     end

--- a/db/migrate/20150105201231_add_author_to_discussion.rb
+++ b/db/migrate/20150105201231_add_author_to_discussion.rb
@@ -1,6 +1,0 @@
-class AddAuthorToDiscussion < ActiveRecord::Migration
-  def change
-    add_column :discussions, :author_id, :integer
-    add_foreign_key :discussions, :users, column: :author_id
-  end
-end

--- a/db/migrate/20150108190811_create_comments.rb
+++ b/db/migrate/20150108190811_create_comments.rb
@@ -1,0 +1,15 @@
+class CreateComments < ActiveRecord::Migration
+  def change
+    create_table :comments do |t|
+      t.text :content
+      t.belongs_to :author, index: true, null: false
+      t.belongs_to :discussion, index: true, null: false
+      t.belongs_to :thread, index: true
+
+      t.timestamps null: false
+    end
+
+    add_foreign_key :comments, :users, column: :author_id
+    add_foreign_key :comments, :discussions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,18 +11,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150105201231) do
+ActiveRecord::Schema.define(version: 20150108190811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "comments", force: :cascade do |t|
+    t.text     "content"
+    t.integer  "author_id",     null: false
+    t.integer  "discussion_id", null: false
+    t.integer  "thread_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+  end
+
+  add_index "comments", ["author_id"], name: "index_comments_on_author_id", using: :btree
+  add_index "comments", ["discussion_id"], name: "index_comments_on_discussion_id", using: :btree
+  add_index "comments", ["thread_id"], name: "index_comments_on_thread_id", using: :btree
+
   create_table "discussions", force: :cascade do |t|
     t.integer  "fid",        null: false
     t.string   "title"
+    t.integer  "author_id",  null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer  "author_id"
   end
+
+  add_index "discussions", ["author_id"], name: "index_discussions_on_author_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",               default: "", null: false
@@ -42,5 +57,7 @@ ActiveRecord::Schema.define(version: 20150105201231) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
 
+  add_foreign_key "comments", "discussions"
+  add_foreign_key "comments", "users", column: "author_id"
   add_foreign_key "discussions", "users", column: "author_id"
 end

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :comment do
+    content { Faker::Lorem.paragraph }
+    author
+    discussion
+  end
+end

--- a/spec/helpers/discussions_helper_spec.rb
+++ b/spec/helpers/discussions_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe DiscussionsHelper, type: :helper do
+
+  describe '#time_ago' do
+
+    it 'works ok for time in the future' do
+      t = Time.now + 3.minutes
+      expect(time_ago(t)).to eq l(t, format: :short)
+    end
+
+  end
+
+end

--- a/spec/helpers/discussions_helper_spec.rb
+++ b/spec/helpers/discussions_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DiscussionsHelper, type: :helper do
 
     it 'works ok for time in the future' do
       t = Time.now + 3.minutes
-      expect(time_ago(t)).to eq l(t, format: :short)
+      expect(time_ago(t)).to eq l(t.in_time_zone('CET'), format: :short)
     end
 
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -4,8 +4,21 @@ RSpec.describe Ability do
   let(:user) { create(:user) }
   let(:ability) { Ability.new(user) }
 
-  it 'author can destroy discussion' do
+  it 'author can destroy discussion with no comments' do
     owned_discussion = create(:discussion, author: user)
+    expect(can?(:destroy, owned_discussion)).to be_truthy
+  end
+
+  it 'author cannot destroy discussion with other user comment' do
+    owned_discussion = create(:discussion, author: user)
+    create(:comment, discussion: owned_discussion)
+    create(:comment, author: user, discussion: owned_discussion)
+    expect(can?(:destroy, owned_discussion)).to be_falsy
+  end
+
+  it 'author can destroy discussion with own comments only' do
+    owned_discussion = create(:discussion, author: user)
+    create(:comment, author: user, discussion: owned_discussion)
     expect(can?(:destroy, owned_discussion)).to be_truthy
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+
+  it { should validate_presence_of :author }
+  it { should validate_presence_of :discussion }
+
+  # TODO Test for exclusion of Thread circular reference
+
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -5,6 +5,30 @@ RSpec.describe Comment, type: :model do
   it { should validate_presence_of :author }
   it { should validate_presence_of :discussion }
 
+  describe '#by' do
+
+    it 'returns empty array on nil user' do
+      create(:comment)
+      expect(Comment.by(nil)).to eq []
+      expect(Comment.by(nil)).not_to eq nil
+    end
+
+    it 'returns only comments by correct author' do
+      u1 = create :user
+      u2 = create :user
+      create(:comment, content: 'a')
+      b = create(:comment, content: 'b', author: u1)
+      c = create(:comment, content: 'c', author: u2)
+      d = create(:comment, content: 'd', author: u2)
+      expect(Comment.count).to eq 4
+      expect(Comment.by(u1)).to include b
+      expect(Comment.by(u2).count).to eq 2
+      expect(Comment.by(u2)).to include c
+      expect(Comment.by(u2)).to include d
+    end
+
+  end
+
   # TODO Test for exclusion of Thread circular reference
 
 end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -57,19 +57,19 @@ RSpec.describe Discussion do
 
   end
 
-  describe '#about_fid' do
+  describe '#about' do
 
     it 'returns empty array on nil fid' do
       # This is to prevent 500 errors when no fid is passed
-      expect(Discussion.about_fid(nil)).to eq []
-      expect(Discussion.about_fid(nil)).not_to eq nil
+      expect(Discussion.about(nil)).to eq []
+      expect(Discussion.about(nil)).not_to eq nil
     end
 
     it 'returns discussions in the newset-first order' do
-      a = create(:discussion)
-      b = create(:discussion, created_at: Time.now - 10.minutes)
-      c = create(:discussion, created_at: Time.now + 5.years)
-      result = Discussion.recently_created
+      a = create(:discussion, fid: 1)
+      b = create(:discussion, created_at: Time.now - 10.minutes, fid: 1)
+      c = create(:discussion, created_at: Time.now + 5.years, fid: 1)
+      result = Discussion.about 1
       expect(result).to eq [c, a, b]
     end
 

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Discussion do
 
   it { should validate_presence_of :fid }
-  it { should validate_presence_of :author }
 
   describe '#about_fid' do
 
@@ -46,7 +45,55 @@ RSpec.describe Discussion do
   end
 
   describe '#recently_commented' do
-    pending 'Waiting for :recently_commented to be implemented.'
+
+    it 'returns empty array when no discussions' do
+      expect(Discussion.recently_commented).to eq []
+      expect(Discussion.recently_commented).not_to eq nil
+    end
+
+    it 'returns all discussions when there are <=5 in total commented' do
+      3.times { create(:comment) }
+      expect(Discussion.recently_commented.count).to eq 3
+    end
+
+    it 'does not return uncommented discussions' do
+      2.times { create(:discussion) }
+      expect(Discussion.count).to eq 2
+      expect(Discussion.recently_commented.count).to eq 0
+      4.times { create(:comment) }
+      expect(Discussion.count).to eq 6
+      expect(Discussion.recently_commented.count).to eq 4
+    end
+
+    it 'does not return duplicate discussions' do
+      c1 = create(:comment)
+      2.times { create(:comment) }
+      3.times { create(:comment, discussion: c1.discussion) }
+      expect(Discussion.count).to eq 3
+      expect(Comment.count).to eq 6
+      expect(Discussion.recently_commented.count).to eq 3
+    end
+
+    it 'returns only 5 discussions' do
+      6.times { create(:comment) }
+      expect(Discussion.recently_commented.count).to eq 5
+    end
+
+    it 'returns discussions in newest comment first order' do
+      a,b,c,d,e,f,z =
+        %w(a b c d e f z).map{ |x| create(:discussion, title: x) }
+      create(:comment, discussion: a)
+      create(:comment, discussion: b, created_at: Time.now - 10.minutes)
+      create(:comment, discussion: c, created_at: Time.now + 5.years)
+      create(:comment, discussion: c, created_at: Time.now - 5.minutes)
+      create(:comment, discussion: d, created_at: Time.now - 3.hours)
+      create(:comment, discussion: e, created_at: Time.now - 15.minutes)
+      create(:comment, discussion: f, created_at: Time.now - 25.minutes)
+      result = Discussion.recently_commented
+      expect(result.count).to eq 5
+      expect(result.map(&:title)).to eq %w(c a b e f)
+    end
+
   end
 
 end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Discussion do
       expect(Discussion.about_fid(nil)).not_to eq nil
     end
 
+    it 'returns discussions in the newset-first order' do
+      a = create(:discussion)
+      b = create(:discussion, created_at: Time.now - 10.minutes)
+      c = create(:discussion, created_at: Time.now + 5.years)
+      result = Discussion.recently_created
+      expect(result).to eq [c, a, b]
+    end
+
   end
 
   describe '#recently_created' do
@@ -31,15 +39,12 @@ RSpec.describe Discussion do
       expect(Discussion.recently_created.count).to eq 3
     end
 
-    it 'returns discussions in newest first order' do
-      create(:discussion, title: 'a')
-      create(:discussion, title: 'b', created_at: Time.now - 10.minutes)
-      create(:discussion, title: 'c', created_at: Time.now + 5.years)
+    it 'returns discussions in the newest-first order' do
+      a = create(:discussion)
+      b = create(:discussion, created_at: Time.now - 10.minutes)
+      c = create(:discussion, created_at: Time.now + 5.years)
       result = Discussion.recently_created
-      expect(result.count).to eq 3
-      expect(result[0].title).to eq 'c'
-      expect(result[1].title).to eq 'a'
-      expect(result[2].title).to eq 'b'
+      expect(result).to eq [c, a, b]
     end
 
   end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -53,16 +53,16 @@ RSpec.describe Discussion do
 
     it 'returns all discussions when there are <=5 in total commented' do
       3.times { create(:comment) }
-      expect(Discussion.recently_commented.count).to eq 3
+      expect(Discussion.recently_commented.all.length).to eq 3
     end
 
     it 'does not return uncommented discussions' do
       2.times { create(:discussion) }
       expect(Discussion.count).to eq 2
-      expect(Discussion.recently_commented.count).to eq 0
+      expect(Discussion.recently_commented.all.length).to eq 0
       4.times { create(:comment) }
       expect(Discussion.count).to eq 6
-      expect(Discussion.recently_commented.count).to eq 4
+      expect(Discussion.recently_commented.all.length).to eq 4
     end
 
     it 'does not return duplicate discussions' do
@@ -71,12 +71,12 @@ RSpec.describe Discussion do
       3.times { create(:comment, discussion: c1.discussion) }
       expect(Discussion.count).to eq 3
       expect(Comment.count).to eq 6
-      expect(Discussion.recently_commented.count).to eq 3
+      expect(Discussion.recently_commented.all.length).to eq 3
     end
 
     it 'returns only 5 discussions' do
       6.times { create(:comment) }
-      expect(Discussion.recently_commented.count).to eq 5
+      expect(Discussion.recently_commented.all.length).to eq 5
     end
 
     it 'returns discussions in newest comment first order' do
@@ -89,8 +89,10 @@ RSpec.describe Discussion do
       create(:comment, discussion: d, created_at: Time.now - 3.hours)
       create(:comment, discussion: e, created_at: Time.now - 15.minutes)
       create(:comment, discussion: f, created_at: Time.now - 25.minutes)
+      expect(Discussion.count).to eq 7
+      expect(Comment.count).to eq 7
       result = Discussion.recently_commented
-      expect(result.count).to eq 5
+      expect(result.all.length).to eq 5
       expect(result.map(&:title)).to eq %w(c a b e f)
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 RSpec.describe User do
 
-  it 'is forever', focus: true do
-    create(:user).destroy
+  it 'is forever' do
+    u = create(:user)
+    u.destroy
     expect(User.count).to eq 1
+    expect(u.errors.full_messages).to eq ['Entities of User cannot be destroyed!']
   end
 
   it 'creates new user while logging using omniauth' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe User do
+
+  it 'is forever', focus: true do
+    create(:user).destroy
+    expect(User.count).to eq 1
+  end
+
   it 'creates new user while logging using omniauth' do
     expect { User.from_omniauth(auth) }.to change { User.count }.by(1)
   end

--- a/spec/views/discussions/_list.html.haml_spec.rb
+++ b/spec/views/discussions/_list.html.haml_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'discussions/_list.html.haml' do
       render partial: 'discussions/list.html.haml',
              locals: { list: [ discussion ] }
 
-      path = discussion_path(I18n.locale, discussion)
+      path = discussion_path(id: discussion.id)
       expect(rendered).
         to have_xpath(".//a[@href='#{path}']")
     end

--- a/spec/views/discussions/recent.html.haml_spec.rb
+++ b/spec/views/discussions/recent.html.haml_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'discussions/recent.html.haml' do
   context 'when discussions are present' do
     it 'displays discussions' do
       6.times { create(:discussion) }
+      @recently_created = Discussion.recently_created
+      @recently_commented = Discussion.recently_commented.all
       render
       Discussion.recently_created.each do |d|
         expect(rendered).to have_link d.title
@@ -27,10 +29,12 @@ RSpec.describe 'discussions/recent.html.haml' do
 
   context 'when comments are present' do
     it 'displays discussions with recent comments' do
-      %w(a b c d e f).map do |title|
+      %w(a b c d e f).each do |title|
         d = create(:discussion, title: title)
         create(:comment, discussion: d)
       end
+      @recently_created = Discussion.recently_created
+      @recently_commented = Discussion.recently_commented.all
       render
       Discussion.recently_commented.each do |d|
         expect(rendered).to have_link d.title

--- a/spec/views/discussions/recent.html.haml_spec.rb
+++ b/spec/views/discussions/recent.html.haml_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'discussions/recent.html.haml' do
+  let(:ability) { Ability.new(user) }
+  let(:user) { create(:user) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+  end
+
+  context 'when no discussions' do
+    it 'displays alert' do
+      render
+      expect(rendered).to have_content 'No discussions are present'
+    end
+  end
+
+  context 'when discussions are present' do
+    it 'displays discussions' do
+      6.times { create(:discussion) }
+      render
+      Discussion.recently_created.each do |d|
+        expect(rendered).to have_link d.title
+      end
+    end
+  end
+
+  context 'when comments are present' do
+    it 'displays discussions with recent comments' do
+      %w(a b c d e f).map do |title|
+        d = create(:discussion, title: title)
+        create(:comment, discussion: d)
+      end
+      render
+      Discussion.recently_commented.each do |d|
+        expect(rendered).to have_link d.title
+      end
+      absent = Discussion.all - Discussion.recently_commented
+      expect(rendered).not_to have_link absent.first.title
+    end
+  end
+
+end


### PR DESCRIPTION
The interesting thing is inside Discussion.recently_commented.

The query we have works properly, but is not chainable - the count method used by specs is simply doing size/length on the result ruby array.

The commented out arel version does the same and is theoretically chainable (for instance, do recently_commented.limit(2) on it). However, count does not work since SQL is not able to count a select like that.

Thus - an interesting arel/sql question :).