### PR TITLE
simple comment create support

### DIFF
--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -2,14 +2,12 @@ class @Discussions
   @initialize = ->
     console.log 'INIT: Discussions initialization'
 
-    $('body').on 'show.bs.collapse', '.discussion-body', ->
-      discussionId = $(this).attr('data-discussion')
-      discussionPath = Routes.discussion_path(
-        discussionId,
-        locale: I18n.locale
-      )
-      $.get discussionPath, (data) =>
-        $("[data-discussion=#{discussionId}] .panel-body").html data
+    $('body').on 'show.bs.collapse', '.discussion-body', (e) =>
+      discussionId = $(e.target).attr('data-discussion')
+      @loadDiscussion(discussionId)
+
+    $('body').on 'ajax:success', '#new_comment', (e, data, status, xhr) ->
+      $('.discussion-body.in .panel-body').html data
 
     $('body').on 'ajax:success', '#new_discussion', (e, data, status, xhr) ->
       $('#discussions').html data
@@ -25,3 +23,12 @@ class @Discussions
 
     $('body').on 'ajax:success', '.delete', (evt, data, status, xhr) ->
       $(this).parents('.panel').fadeOut()
+
+
+  @loadDiscussion = (discussionId) ->
+    discussionPath = Routes.discussion_path(
+      discussionId,
+      locale: I18n.locale
+    )
+    $.get discussionPath, (data) =>
+      $("[data-discussion=#{discussionId}] .panel-body").html data

--- a/app/assets/stylesheets/discussions.scss
+++ b/app/assets/stylesheets/discussions.scss
@@ -13,6 +13,10 @@
 
   .panel-body {
     background-color: #FBFBF0;
+
+    .time {
+      color: #808080;
+    }
   }
 
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,6 @@
 class CommentsController < ApplicationController
+  include Ajaxable
+
   load_and_authorize_resource only: [:create]
   layout false
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,24 @@
+class CommentsController < ApplicationController
+  load_and_authorize_resource only: [:create]
+  layout false
+
+  rescue_from CanCan::AccessDenied do |exception|
+    render_error(exception.message, status: current_user ? 403 : 401)
+  end
+
+
+  def create
+    @comment.save!
+    @discussion = @comment.discussion
+    render 'discussions/show'
+  end
+
+
+  private
+
+  def comment_params
+    params.require(:comment).
+           permit(:content, :discussion_id).
+           merge(author: current_user)
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,11 +4,6 @@ class CommentsController < ApplicationController
   load_and_authorize_resource only: [:create]
   layout false
 
-  rescue_from CanCan::AccessDenied do |exception|
-    render_error(exception.message, status: current_user ? 403 : 401)
-  end
-
-
   def create
     @comment.save!
     @discussion = @comment.discussion

--- a/app/controllers/concerns/ajaxable.rb
+++ b/app/controllers/concerns/ajaxable.rb
@@ -1,0 +1,9 @@
+module Ajaxable
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from CanCan::AccessDenied do |exception|
+      render_error(exception.message, status: current_user ? 403 : 401)
+    end
+  end
+end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,10 +1,8 @@
 class DiscussionsController < ApplicationController
+  include Ajaxable
+
   load_and_authorize_resource only: [:create, :destroy]
   layout false
-
-  rescue_from CanCan::AccessDenied do |exception|
-    render_error(exception.message, status: current_user ? 403 : 401)
-  end
 
   def index
     if params[:fid]

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,6 +9,8 @@ class Ability
         discussion.author_id == user.id &&
           discussion.comments.by(user) == discussion.comments
       end
+
+      can :create, Comment, author_id: user.id
     end
   end
 end

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -8,3 +8,16 @@
         = time_ago comment.created_at
       %p
         = comment.content
+
+.box
+  .avatar
+    %img{ src: current_user.image }
+  .page-feed-content
+    = form_for Comment.new, remote: true do |f|
+      .form-group
+        = f.hidden_field :discussion_id, value: @discussion.id
+        = f.text_area :content,
+          placeholder: t('discussions.comment.content.new_default'),
+          class: 'form-control'
+
+      = f.submit t('discussions.comment.save'), class: 'btn btn-default btn-xs'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,11 @@ en:
           Please login if you would like to start a new discussion. Login
           buttons are located in the top-right corner.
       save: Save
+    comment:
+      content:
+        new_default: Put your comment text here...
+        purged: (comment removed by the author)
+      save: Send
 
   map:
     plan: Plan name

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -75,6 +75,11 @@ pl:
           Proszę zaloguj się, jeśli chcesz rozpocząć nową dyskusję. W tym celu
           użyj przycisków znajdujących się w prawym górnym rogu ekranu.
       save: Utwórz
+    comment:
+      content:
+        new_default: Tutaj wpisz swój komentarz...
+        purged: (komentarz usunięty przez autora)
+      save: Wyślij
 
   map:
     plan: Nazwa planu

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,7 @@ Rails.application.routes.draw do
 
     resources :districts, only: [:show]
     resources :discussions, only: [:index, :show, :create, :destroy]
+    resources :comments, only: [:create]
   end
+
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Ability do
+
   let(:user) { create(:user) }
   let(:ability) { Ability.new(user) }
 
@@ -37,7 +38,18 @@ RSpec.describe Ability do
     expect(ability.can?(:create, build(:discussion))).to be_falsy
   end
 
+  it 'logged in user can post comments' do
+    comment = build(:comment, author: user)
+    expect(can?(:create, comment)).to be_truthy
+  end
+
+  it 'anonymous is not able to post comments' do
+    ability = Ability.new(nil)
+    expect(ability.can?(:create, build(:comment))).to be_falsy
+  end
+
   def can?(action, subject)
     ability.can?(action, subject)
   end
+
 end


### PR DESCRIPTION
Notes:
 - I did this to be able to go into map marker placing (per-comment, as we decided) later on
 - not using nested resources as I think we will not need to go as deep as a single comment level with URLs; and nesting complicates thing
 - the view code might be written better but it will be rewritten anyway for display of purged/edited comments
 - no nicer styling yet.
