### PR TITLE
District contours when zoom < 15

### DIFF
--- a/app/assets/javascripts/zoning_map.js.coffee
+++ b/app/assets/javascripts/zoning_map.js.coffee
@@ -96,6 +96,11 @@ class @ZoningMap
       # Save the svg element of that tooltip for later removing
       oldTooltipElement = e.originalEvent.fromElement
 
+    @swapLayers = (from, to) ->
+      @zoningMap.removeLayer from
+      unless @zoningMap.hasLayer to
+        @zoningMap.addLayer to
+
     @districtContours.on 'mouseover', (e) =>
       mouseoverFunc(e, @featureColor(e.layer.feature), @districtContours)
       @createDistrictTooltip e
@@ -120,11 +125,9 @@ class @ZoningMap
     @detailedZoning.on 'click', (e) =>
       clickFunc(e, Config.ZONE_DEEP_COLOR, @detailedZoning)
 
-    @zoningMap.on 'zoomstart', (e) =>
+    @zoningMap.on 'zoomend', (e) =>
       if e.target.getZoom() < 15
-        @zoningMap.removeLayer @detailedZoning
-        unless @zoningMap.hasLayer @districtContours
-          @zoningMap.addLayer @districtContours
+        @swapLayers(@detailedZoning, @districtContours)
 
     # Binding popup templates to features of both layers, to be shown on feature click
     PopupTemplates.bindPopup @detailedZoning, PopupTemplates.zonePopupTemplate()
@@ -135,9 +138,7 @@ class @ZoningMap
 
     $('#zoom-out-button').on 'click', =>
       # Assure only districts are shown
-      @zoningMap.removeLayer @detailedZoning
-      unless @zoningMap.hasLayer @districtContours
-        @zoningMap.addLayer @districtContours
+      @swapLayers(@detailedZoning, @districtContours)
       # Zoom the map to proper bounds
       southWest = L.latLng Config.MAX_BOUNDS_SOUTH, Config.MAX_BOUNDS_WEST
       northEast = L.latLng Config.MAX_BOUNDS_NORTH, Config.MAX_BOUNDS_EAST

--- a/app/assets/javascripts/zoning_map.js.coffee
+++ b/app/assets/javascripts/zoning_map.js.coffee
@@ -120,6 +120,12 @@ class @ZoningMap
     @detailedZoning.on 'click', (e) =>
       clickFunc(e, Config.ZONE_DEEP_COLOR, @detailedZoning)
 
+    @zoningMap.on 'zoomstart', (e) =>
+      if e.target.getZoom() < 15
+        @zoningMap.removeLayer @detailedZoning
+        unless @zoningMap.hasLayer @districtContours
+          @zoningMap.addLayer @districtContours
+
     # Binding popup templates to features of both layers, to be shown on feature click
     PopupTemplates.bindPopup @detailedZoning, PopupTemplates.zonePopupTemplate()
 


### PR DESCRIPTION
It implements scenario defined in #76 issue. When zoom is smaller than 15 district contours layer is added and detailed layer is removed.