### PR TITLE
New discussion display

### DIFF
--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -9,12 +9,17 @@ class @Discussions
     $('body').on 'ajax:success', '#new_comment', (e, data, status, xhr) ->
       $('#discussions').html data
 
-    $('body').on 'ajax:success',
-                 '#new_discussion, #back-to-discussions',
-                 (e, data, status, xhr) ->
+    $('body').on 'ajax:success'
+               , '#new_discussion, #back-to-discussions'
+               , (e, data, status, xhr) ->
       $('#discussions').html data
       $('#new-discussion #discussion_title').val('')
       $('#new-discussion').collapse('hide')
+
+    $('body').on 'ajax:success'
+               , '#back-to-discussions'
+               , (e, data, status, xhr) ->
+      $('#discussions').html data
 
     $('body').on 'click', 'a[href=#discussions-tab]', ->
       discussionsPath = Routes.discussions_path(

--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -9,13 +9,12 @@ class @Discussions
     $('body').on 'ajax:success', '#new_comment', (e, data, status, xhr) ->
       $('#discussions').html data
 
-    $('body').on 'ajax:success', '#new_discussion', (e, data, status, xhr) ->
+    $('body').on 'ajax:success',
+                 '#new_discussion, #back-to-discussions',
+                 (e, data, status, xhr) ->
       $('#discussions').html data
       $('#new-discussion #discussion_title').val('')
       $('#new-discussion').collapse('hide')
-
-    $('body').on 'ajax:success', '#back-to-discussions', (e, data, status, xhr) ->
-      $('#discussions-tab').html data
 
     $('body').on 'click', 'a[href=#discussions-tab]', ->
       discussionsPath = Routes.discussions_path(

--- a/app/assets/javascripts/discussions.js.coffee
+++ b/app/assets/javascripts/discussions.js.coffee
@@ -7,12 +7,15 @@ class @Discussions
       @loadDiscussion(discussionId)
 
     $('body').on 'ajax:success', '#new_comment', (e, data, status, xhr) ->
-      $('.discussion-body.in .panel-body').html data
+      $('#discussions').html data
 
     $('body').on 'ajax:success', '#new_discussion', (e, data, status, xhr) ->
       $('#discussions').html data
       $('#new-discussion #discussion_title').val('')
       $('#new-discussion').collapse('hide')
+
+    $('body').on 'ajax:success', '#back-to-discussions', (e, data, status, xhr) ->
+      $('#discussions-tab').html data
 
     $('body').on 'click', 'a[href=#discussions-tab]', ->
       discussionsPath = Routes.discussions_path(
@@ -30,5 +33,6 @@ class @Discussions
       discussionId,
       locale: I18n.locale
     )
+    history.pushState(null, document.title, discussionPath)
     $.get discussionPath, (data) =>
-      $("[data-discussion=#{discussionId}] .panel-body").html data
+      $('#discussions').html data

--- a/app/assets/javascripts/dispatcher.js.coffee
+++ b/app/assets/javascripts/dispatcher.js.coffee
@@ -11,10 +11,24 @@ class Dispatcher
 
     return false unless dispatch
 
-    console.log "INIT: #{dispatch} dispatched"
+    console.log "INIT [Dispatcher]: #{dispatch} dispatched"
+
+    @initZoningMap()
 
     switch dispatch
       when 'home:index'
-        new ZoningMap
-        PopupTemplates.initialize()
+        Discussions.initialize() #Needed for discussion load
+      when 'discussions:show'
         Discussions.initialize()
+        discussionId = window.location.pathname.split('/').pop()
+        Discussions.loadDiscussion(discussionId)
+        @switchTabs('#discussions-tab')
+
+  initZoningMap: ->
+    console.log 'INIT [Dispatcher]: initializing Zoning Map component'
+    new ZoningMap
+    PopupTemplates.initialize()
+
+  switchTabs: (targetTab) ->
+    console.log "INIT [Dispatcher]: switching left section to #{targetTab}"
+    $("#left-section a[href=#{targetTab}]").tab 'show'

--- a/app/assets/javascripts/popup_templates.js.coffee
+++ b/app/assets/javascripts/popup_templates.js.coffee
@@ -23,6 +23,9 @@ class @PopupTemplates
   # Run as dynamic functions in order to be able to use proper locales
   @zonePopupTemplate = -> """
     <h3>{OZNACZENIE} ({RODZAJ_OZN})</h3>
+    <small>
+      {ZONE_USE}
+    </small><br>
     #{I18n.t('map.plan')}: {NAZWA_MPZP}<br>
     <div class="btn-group" role="group">
       <button type="button" class="btn btn-sm"
@@ -47,3 +50,4 @@ class @PopupTemplates
         $.extend feature.properties,
           NR_PLANU: if feature.properties.NR_PLANU then " (#{feature.properties.NR_PLANU})" else ""
           BIP: "<a href='#{feature.properties.WWW}'>#{I18n.t('krakow.mpzp.bip_link')}</a><br>"
+          ZONE_USE: I18n.t("use_type.#{feature.properties.RODZAJ_OZN}")

--- a/app/assets/javascripts/zoning_map.js.coffee
+++ b/app/assets/javascripts/zoning_map.js.coffee
@@ -4,7 +4,7 @@ class @ZoningMap
 
     # Create a map in the "map" div, set the view to Kraków and zoom level to 13
     @zoningMap = L.map('zoning-map', { zoomControl: false })
-      .setView [50.075, 19.92], 15
+                  .setView [50.06, 19.95], 13
     new L.Control.Zoom(
       zoomInTitle: I18n.t('map.zoom_in')
       zoomOutTitle: I18n.t('map.zoom_out')

--- a/app/assets/javascripts/zoning_map.js.coffee
+++ b/app/assets/javascripts/zoning_map.js.coffee
@@ -4,7 +4,7 @@ class @ZoningMap
 
     # Create a map in the "map" div, set the view to Kraków and zoom level to 13
     @zoningMap = L.map('zoning-map', { zoomControl: false })
-      .setView [50.06, 19.95], 13
+      .setView [50.075, 19.92], 15
     new L.Control.Zoom(
       zoomInTitle: I18n.t('map.zoom_in')
       zoomOutTitle: I18n.t('map.zoom_out')

--- a/app/assets/stylesheets/discussions.scss
+++ b/app/assets/stylesheets/discussions.scss
@@ -20,3 +20,31 @@
   }
 
 }
+
+.discussion {
+  color: #525252;
+
+  .discussion-header {
+    padding: 10px;
+    color: #FBFBF0;
+    background-color: #436E90;
+    border-color: #436E90;
+
+    #back-to-discussions {
+      color: #FBFBF0;
+      padding-right: 10px;
+
+      :hover {
+        color: #dbdbdb;
+      }
+    }
+  }
+
+  .discussion-item {
+    background-color: #FBFBF0;
+
+    .comment-body {
+      padding-left: 55px;
+    }
+  }
+}

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -7,6 +7,9 @@ class DiscussionsController < ApplicationController
   def index
     if params[:fid]
       @discussions = Discussion.about params[:fid]
+      if params[:list_only]
+        render partial: 'list', object: @discussions
+      end
     else
       @recently_created = Discussion.recently_created
       @recently_commented = Discussion.recently_commented.all

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -23,7 +23,8 @@ class DiscussionsController < ApplicationController
     if request.xhr?
       render 'show', layout: false
     else
-      render 'index', layout: true
+      # render 'index', layout: true
+      render 'home/index', layout: true
     end
   end
 

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -2,7 +2,7 @@ class DiscussionsController < ApplicationController
   include Ajaxable
 
   load_and_authorize_resource only: [:create, :destroy]
-  layout false
+  layout false, except: :show
 
   def index
     if params[:fid]
@@ -19,6 +19,12 @@ class DiscussionsController < ApplicationController
 
   def show
     @discussion = Discussion.find params[:id]
+
+    if request.xhr?
+      render 'show', layout: false
+    else
+      render 'index', layout: true
+    end
   end
 
   def create

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -9,4 +9,13 @@ module DiscussionsHelper
     end
   end
 
+  def discussion_title(discussion)
+    if discussion.title.empty?
+      t 'discussions.discussion.title.default',
+        id: discussion.id, fid: discussion.fid
+    else
+      discussion.title
+    end
+  end
+
 end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -10,11 +10,11 @@ module DiscussionsHelper
   end
 
   def discussion_title(discussion)
-    if discussion.title.empty?
+    if discussion.title.present?
+      discussion.title
+    else
       t 'discussions.discussion.title.default',
         id: discussion.id, fid: discussion.fid
-    else
-      discussion.title
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -19,4 +19,10 @@ class Comment < ActiveRecord::Base
 
   scope :by, ->(user) { where(author: user) }
 
+
+  # def purge
+  #   content = I18n.t 'discussions.comment.content.purged'
+  #   save
+  # end
+
 end

--- a/app/views/discussions/_list.html.haml
+++ b/app/views/discussions/_list.html.haml
@@ -6,11 +6,7 @@
         .panel-heading{ role: 'tab' }
           %a.collapsed{ href: "[data-discussion=#{discussion.id}]",
           data: { toggle: 'collapse', parent: '.discussion-list' }}
-            - if discussion.title.empty?
-              = t 'discussions.discussion.title.default',
-                  id: discussion.id, fid: discussion.fid
-            - else
-              = discussion.title
+            = discussion_title discussion
           .pull-right
             - if can?(:destroy, discussion)
               = link_to discussion_path(id: discussion.id),

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -1,13 +1,24 @@
-- @discussion.comments.each do |comment|
-  .box
-    .avatar
-      %img{ src: comment.author.image }
-    .page-feed-content
-      %small.time
-        = comment.author.name
-        = time_ago comment.created_at
-      %p
-        = comment.content
+%ul.list-group.discussion
+
+  %li.list-group-item.discussion-header
+    %h3
+      = link_to discussions_path(fid: @discussion.fid),
+                id: 'back-to-discussions',
+                remote: true, class: 'pull-left' do
+        = icon('arrow-left')
+    %h4.list-group-item-heading
+      = discussion_title @discussion
+
+  - @discussion.comments.each do |comment|
+    %li.list-group-item.discussion-item
+      .avatar
+        %img{ src: comment.author.image }
+      .comment-body
+        %small.time
+          = comment.author.name
+          = time_ago comment.created_at
+        %p
+          = comment.content
 
 .box
   .avatar

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -2,7 +2,7 @@
 
   %li.list-group-item.discussion-header
     %h3
-      = link_to discussions_path(fid: @discussion.fid),
+      = link_to discussions_path(fid: @discussion.fid, list_only: true),
                 id: 'back-to-discussions',
                 remote: true, class: 'pull-left' do
         = icon('arrow-left')

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -5,5 +5,3 @@
       data: { placement: 'bottom' },
       title: t('nav.zoom_out') do
         = icon 'expand'
-
-#zoning-map

--- a/app/views/layouts/_left_section.html.haml
+++ b/app/views/layouts/_left_section.html.haml
@@ -26,7 +26,8 @@
     #info-tab.tab-pane.active
       = render 'home/instructions'
     #discussions-tab.tab-pane
-      = t 'nav.tabs.discussions'
+      #discussions
+        = t 'nav.tabs.discussions'
     #amendments-tab.tab-pane
       = t 'nav.tabs.amendments'
     #profile-tab.tab-pane

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,8 @@
 
         #content.col-xs-12.col-sm-7.full-content
           = yield
+          #zoning-map
+
     = render 'layouts/flash'
     :javascript
       console.log('INIT: setting current locale');

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,3 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
-
-if Rails.env.development?
-  Discussion.create title: 'Do we or do we not build our new office here?', fid:  5712
-  Discussion.create title: 'Relokacja restauracji Przeskok', fid:  5712
-  Discussion.create title: 'Ten trawnik wymaga pomocy!', fid:  5727
-end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+if Rails.env.development?
+  Discussion.create title: 'Do we or do we not build our new office here?', fid:  5712
+  Discussion.create title: 'Relokacja restauracji Przeskok', fid:  5712
+  Discussion.create title: 'Ten trawnik wymaga pomocy!', fid:  5727
+end

--- a/spec/helpers/discussions_helper_spec.rb
+++ b/spec/helpers/discussions_helper_spec.rb
@@ -11,4 +11,25 @@ RSpec.describe DiscussionsHelper, type: :helper do
 
   end
 
+  describe '#discussion_title' do
+
+    it 'throws exception on nil discussion' do
+      expect{ discussion_title(nil) }.to raise_error(NoMethodError)
+    end
+
+    it 'provides default on nil or empty title' do
+      d = create(:discussion, title: nil)
+      expect(discussion_title(d)).
+        to eq t('discussions.discussion.title.default',
+                id: d.id, fid: d.fid
+               )
+      d = create(:discussion, title: '')
+      expect(discussion_title(d)).
+        to eq t('discussions.discussion.title.default',
+                id: d.id, fid: d.fid
+               )
+    end
+
+  end
+
 end

--- a/spec/models/discussion_spec.rb
+++ b/spec/models/discussion_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Discussion do
 
   it { should validate_presence_of :fid }
+  it { should validate_presence_of :author }
 
   describe '#destroy' do
 


### PR DESCRIPTION
A branch for nicer discussion layout management - shows the discussion in the left pane and allows the user to go back to the list.

Uses browser's history pushState (see discussions.js.coffee) to overwrite the address bar to the URL.

The biggest problem now is that we have no easy solution to render to entire layout/view for a given discussion. Some neat trick to do that without writing a lot of code would be appreciated :).

Also, the "newest comments" mode is not supported (but don't mind that).
